### PR TITLE
Fix ensemble model attribute error

### DIFF
--- a/Bot-Trading_Swing.py
+++ b/Bot-Trading_Swing.py
@@ -10415,6 +10415,11 @@ def load_latest_model(symbol, model_type="ensemble"):
             is_valid = True
 
         if is_valid:
+            # Add backward compatibility for old model files missing model_weights_dynamic
+            if ensemble_model and not hasattr(ensemble_model, 'model_weights_dynamic'):
+                ensemble_model.model_weights_dynamic = {}
+                logging.info(f"🔧 Added missing model_weights_dynamic attribute to {symbol} {model_type} model")
+            
             logging.info(f" Loaded_compatible model ({model_type}) for {symbol} from: {latest_pkl_file}")
             return model_data
         else:


### PR DESCRIPTION
Add backward compatibility for `model_weights_dynamic` during model loading to prevent `AttributeError`.

The `AttributeError` occurred because older pickled `EnsembleModel` instances lacked the `model_weights_dynamic` attribute. This change ensures that if a loaded model is missing this attribute, it is initialized, allowing the bot to function correctly and make predictions.

---
<a href="https://cursor.com/background-agent?bcId=bc-745333f7-951c-4f1f-9b5f-a38afa63f020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-745333f7-951c-4f1f-9b5f-a38afa63f020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

