### PR TITLE
Fix ethusd db write syntax error

### DIFF
--- a/Bot-Trading_Swing.py
+++ b/Bot-Trading_Swing.py
@@ -18329,7 +18329,7 @@ class EnhancedTradingBot:
                     """INSERT INTO trades (symbol, signal, entry_price, exit_price,
                                           closed_at, reason, pips, confidence,
                                           signal_price, execution_slippage_pips, spread_cost_pips)
-                       VALUES (, , , , , , , , , , )""",
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                     trade_data,
                 )
                 self.conn.commit()
@@ -23259,7 +23259,7 @@ class AdvancedFeatureStore:
             conn.execute("""
                 INSERT OR REPLACE INTO feature_schema
                 (feature_name, feature_type, min_value, max_value, description, created_at)
-                VALUES (, , , , , )
+                VALUES (?, ?, ?, ?, ?, ?)
             """, (feature_name, feature_type, min_value, max_value, description, datetime.now().isoformat()))
 
     def validate_feature(self, feature_name, feature_value):
@@ -23297,7 +23297,7 @@ class AdvancedFeatureStore:
                 conn.execute("""
                     INSERT OR REPLACE INTO features
                     (symbol, timestamp, timeframe, feature_name, feature_value, feature_type, created_at)
-                    VALUES (, , , , , , )
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
                 """, (symbol, timestamp, timeframe, feature_name, feature_value, feature_type, datetime.now().isoformat()))
 
     def get_features(self, symbol, timeframe, start_time=None, end_time=None, feature_names=None):


### PR DESCRIPTION
Fix 'near ',': syntax error' in SQL INSERT statements by replacing empty VALUES placeholders with `?`.

The original SQL INSERT statements had empty `VALUES` clauses (e.g., `VALUES (, , ,)`), which caused a `near ',': syntax error` in SQLite when attempting to write data to the database for any symbol. This PR corrects these statements to use proper `?` placeholders for parameterized queries.

---
<a href="https://cursor.com/background-agent?bcId=bc-2b5bb396-c303-42aa-959a-33a736a940e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2b5bb396-c303-42aa-959a-33a736a940e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

